### PR TITLE
Fix config.w32

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -5,14 +5,14 @@ ARG_WITH("xlswriter", "xlswriter support", "no");
 
 if (PHP_XLSWRITER != "no") {
 
-    if (CHECK_LIB("LibXlsxWriter.lib", "xlswriter", PHP_XLSWRITER) &&
-        CHECK_HEADER_ADD_INCLUDE("xlsxwriter.h", "CFLAGS_XLSWRITER", PHP_PHP_BUILD + "\\MSVCLibXlsxWriter\\libxlsxwriter\\include;" + PHP_XLSWRITER) &&
-        CHECK_HEADER_ADD_INCLUDE("packager.h", "CFLAGS_XLSWRITER", PHP_PHP_BUILD + "\\MSVCLibXlsxWriter\\libxlsxwriter\\include\\xlsxwriter;" + PHP_XLSWRITER) &&
-        CHECK_HEADER_ADD_INCLUDE("format.h", "CFLAGS_XLSWRITER", PHP_PHP_BUILD + "\\MSVCLibXlsxWriter\\libxlsxwriter\\include\\xlsxwriter;" + PHP_XLSWRITER)) {
+    if (CHECK_LIB("xlsxwriter.lib;xlsxwriter_a.lib", "xlswriter", PHP_XLSWRITER) &&
+        CHECK_HEADER_ADD_INCLUDE("xlsxwriter.h", "CFLAGS_XLSWRITER", PHP_PHP_BUILD + "\\include;" + PHP_XLSWRITER) &&
+        CHECK_HEADER_ADD_INCLUDE("xlsxwriter/packager.h", "CFLAGS_XLSWRITER", PHP_PHP_BUILD + "\\include;" + PHP_XLSWRITER) &&
+        CHECK_HEADER_ADD_INCLUDE("xlsxwriter/format.h", "CFLAGS_XLSWRITER", PHP_PHP_BUILD + "\\include;" + PHP_XLSWRITER)) {
         EXTENSION("xlswriter", "xls_writer.c")
         ADD_SOURCES(configure_module_dirname + "\\kernel", "common.c resource.c exception.c excel.c write.c format.c", "xlswriter");
     } else {
-        WARNING("xlswriter not enabled, LibXlsxWriter.lib or headers not found");
+        WARNING("xlswriter not enabled, xlsxwriter.lib or headers not found");
     }
 
 }


### PR DESCRIPTION
Just some revamp of config.w32 to comply with the usual PHP case and also so the build host can work. PHP would usually expect a directory structure like usual bin,lib,include when checking for dependency packages. I'd see no reason it should be different in this case. You'll find the libxslxwriter builds under https://windows.php.net/downloads/pecl/deps/, done using cmake. It produces a static library by default, for PHP we usually append `_a` to the static lib names. I haven't done it for simplicity, as it would need to patch the actual cmake script, etc. Can be done later or if you build the libs yourself, the patch will support both dynamic and shared lib names, anyway.

The deps are put onto the build host already. You'll find the current snapshot builds under https://windows.php.net/downloads/pecl/snaps/xlswriter/1.0.1/.

Thanks.