### PR TITLE
Add link to PECL site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please refer to the image below. PHPExcel has been unable to work properly for m
 
 [中文文档](https://github.com/viest/php-ext-excel-export/blob/master/README_zh.md) | [Documents](https://github.com/viest/php-ext-excel-export/wiki)
 
-![pecl](https://github.com/viest/php-excel-writer/blob/master/resource/pecl.png)
+[![pecl](https://github.com/viest/php-excel-writer/blob/master/resource/pecl.png)](https://pecl.php.net/package/xlswriter)
 
 #### License
 


### PR DESCRIPTION
Hello, this patch adds also a link to PECL site so we know which pecl extension this is from GitHub directly also.

Thanks for checking this out or considering merging it.