### PR TITLE
Bad arginfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ tmp-php.ini
 cmake-build-debug
 CMakeLists.txt
 local_test.php
+xlswriter-*.tgz

--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -61,9 +61,13 @@ ZEND_BEGIN_ARG_INFO_EX(xls_construct_arginfo, 0, 0, 1)
                 ZEND_ARG_INFO(0, config)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(xls_file_name_arginfo, 0, 0, 2)
+ZEND_BEGIN_ARG_INFO_EX(xls_file_name_arginfo, 0, 0, 1)
                 ZEND_ARG_INFO(0, file_name)
                 ZEND_ARG_INFO(0, sheet_name)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(xls_const_memory_arginfo, 0, 0, 1)
+                ZEND_ARG_INFO(0, file_name)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(xls_file_add_sheet, 0, 0, 1)
@@ -496,7 +500,7 @@ zend_function_entry xls_methods[] = {
         PHP_ME(vtiful_xls, __construct,   xls_construct_arginfo,      ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
         PHP_ME(vtiful_xls, fileName,      xls_file_name_arginfo,      ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, addSheet,      xls_file_add_sheet,         ZEND_ACC_PUBLIC)
-        PHP_ME(vtiful_xls, constMemory,   xls_file_name_arginfo,      ZEND_ACC_PUBLIC)
+        PHP_ME(vtiful_xls, constMemory,   xls_const_memory_arginfo,   ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, header,        xls_header_arginfo,         ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, data,          xls_data_arginfo,           ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, output,        NULL,                       ZEND_ACC_PUBLIC)

--- a/package.xml
+++ b/package.xml
@@ -73,6 +73,8 @@
                 <file role="src" name="014.phpt" />
                 <file role="src" name="015.phpt" />
                 <file role="src" name="016.phpt" />
+                <file role="src" name="017.phpt" />
+                <file role="src" name="018.phpt" />
             </dir>
         </dir>
     </contents>


### PR DESCRIPTION
Version 1.2.0 introduces an unwanted change in 2 method prototypes

```
        Method [ <internal:xlswriter> public method fileName ] {
          - Parameters [2] {
            Parameter #0 [ <required> $file_name ]
            Parameter #1 [ <required> $sheet_name ]
          }
        }
```
According to code, the second (new) parameter is optional.
(having it mandatory will be a BC break)

```
        Method [ <internal:xlswriter> public method constMemory ] {
          - Parameters [2] {
            Parameter #0 [ <required> $file_name ]
            Parameter #1 [ <required> $sheet_name ]
          }
        }
```

According to code, there is no second parameter.

Which show, having same arginfo struct for various methods is a bad idea ;)
