### PR TITLE
Remove unused $Id$ Git ident attribute

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,4 +1,3 @@
-// $Id$
 // vim:ft=javascript
 
 ARG_WITH("xlswriter", "xlswriter support", "no");


### PR DESCRIPTION
Hello, the `$Id$` keywords were used in Subversion where they were replaced with last revision number, author, and time. In Git this functionality is different and each file would need to be defined manually in the
`.gitattributes` file to be replaceable. This patch simplifies this with removal of the Git ident attribute.

Thanks for considering merging this or checking it out.