### PR TITLE
display library version in phpinfo

### DIFF
--- a/xls_writer.c
+++ b/xls_writer.c
@@ -72,6 +72,9 @@ PHP_MINFO_FUNCTION(xlswriter)
 #if defined(PHP_XLSWRITER_VERSION)
     php_info_print_table_row(2, "Version", PHP_XLSWRITER_VERSION);
 #endif
+#if defined(LXW_VERSION)
+    php_info_print_table_row(2, "Library version", LXW_VERSION);
+#endif
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
Common practice to have this information, helpful for support, especially as libxlsxwriter API is not stable yet and without soname (symbols versionning) see https://github.com/jmcnamara/libxlsxwriter/issues/167

Example 0.7.7 to 0.7.8 introduce some breaking changes
https://rpms.remirepo.net/compat_reports/libxlsxwriter/0.7.7_to_0.7.8/compat_report.html