### PR TITLE
report both buildtime and runtime libxlsxwriter versions

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -61,8 +61,15 @@ if test "$PHP_XLSWRITER" != "no"; then
             ],[
                 -L$XLSXWRITER_DIR/$PHP_LIBDIR -lm
             ])
+            PHP_CHECK_LIBRARY(xlsxwriter, lxw_version,
+            [
+                AC_DEFINE(HAVE_LXW_VERSION, 1, [ lxw_version available in 0.7.9 ])
+            ],[
+            ],[
+                -L$XLSXWRITER_DIR/$PHP_LIBDIR -lm
+            ])
         fi
-        AC_DEFINE(HAVE_LIBXLSXWRITER,1,[ ])
+        AC_DEFINE(HAVE_LIBXLSXWRITER, 1, [ use system libxlsxwriter ])
     else
         AC_MSG_RESULT([use the bundled library])
         xls_writer_sources="$xls_writer_sources $libxlsxwriter_sources"

--- a/xls_writer.c
+++ b/xls_writer.c
@@ -74,7 +74,12 @@ PHP_MINFO_FUNCTION(xlswriter)
 #endif
 #ifdef LXW_VERSION
 #ifdef HAVE_LIBXLSXWRITER
-    php_info_print_table_row(2, "system libxlsxwriter version", LXW_VERSION);
+    /* Build time */
+    php_info_print_table_row(2, "libxlsxwriter headers version", LXW_VERSION);
+#ifdef HAVE_LXW_VERSION
+    /* Run time, available since 0.7.9 */
+    php_info_print_table_row(2, "libxlsxwriter library version", lxw_version());
+#endif
 #else
     php_info_print_table_row(2, "bundled libxlsxwriter version", LXW_VERSION);
 #endif


### PR DESCRIPTION
`lxw_version() `available in libxlsxwriter version 0.7.9 recently released.